### PR TITLE
Add tracks and its nested objects to hash.

### DIFF
--- a/lib/guitar_pro_parser/song.rb
+++ b/lib/guitar_pro_parser/song.rb
@@ -162,14 +162,16 @@ module GuitarProParser
           'transcriber' => transcriber,
           'instructions' => instructions,
           'notices' => notices
-        }
+        },
+        'tracks' => tracks
       }
     end
 
     # Converts Song object to JSON
     # @return [String] song as a JSON
     def to_json
-      Oj.dump(to_hash)
+      # Use compat mode so that the export is compatible with other JSON readers.
+      Oj.dump(to_hash, :mode => :compat)
     end
 
   end


### PR DESCRIPTION
Closes #1

This PR adds tracks and its nested objects such as  bars, beats and notes to the hash method so that they can be exported to JSON or any other compatible format. You can find a sample export [here](https://dl.dropboxusercontent.com/u/31469536/sample_song.json).
